### PR TITLE
Feat: 약관 동의 페이지 ui 임시구현

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:live_frontend/theme/app_colors.dart';
 import 'routers/app_router.dart';
 
 class MyApp extends ConsumerWidget {
@@ -19,8 +20,12 @@ class MyApp extends ConsumerWidget {
           routerConfig: router,
           title: 'Lively',
           theme: ThemeData(
+            checkboxTheme: CheckboxThemeData(
+              side: const BorderSide(
+                color: AppColors.greenNormal,
+              ), // ✅ 보더 색만 지정
+            ),
             colorScheme: ColorScheme.fromSeed(seedColor: Colors.black),
-            // colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
             useMaterial3: true,
           ),
         );

--- a/lib/routers/app_router.dart
+++ b/lib/routers/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:live_frontend/screens/terms/terms_screen.dart';
 import '../screens/login/login_screen.dart';
 import '../screens/home.dart';
 import '../providers/auth_provider.dart';
@@ -33,14 +34,20 @@ final routerProvider = Provider<GoRouter>((ref) {
       // 2. 로그인 안 돼있고 로그인 페이지가 아니면 → 로그인으로
       if (!isLoggedIn && !isOnLoginPage) return '/login';
 
-      // 3. 로그인 돼있는데 로그인 페이지 가려고 하면 → 홈으로
-      if (isLoggedIn && isOnLoginPage) return '/home';
+      // 3. 로그인 돼있는데 로그인 페이지 가려고 하면 → 약관 동의 화면 (임시처리)
+      if (isLoggedIn && isOnLoginPage) return '/terms';
 
       return null;
     },
     routes: [
       GoRoute(path: '/login', builder: (context, state) => const LoginScreen()),
       GoRoute(path: '/home', builder: (context, state) => const HomeScreen()),
+      GoRoute(
+        path: '/terms',
+        builder: (context, state) {
+          return TermsScreen();
+        },
+      ),
     ],
   );
 });

--- a/lib/screens/terms/terms_screen.dart
+++ b/lib/screens/terms/terms_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:live_frontend/theme/app_text_styles.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+
+class TermsScreen extends StatefulWidget {
+  @override
+  _TermsScreenState createState() => _TermsScreenState();
+}
+
+class _TermsScreenState extends State<TermsScreen> {
+  bool agreedToAll = false;
+  bool agreedToService = false;
+  bool agreedToPrivacy = false;
+  bool isOlderThen14 = false;
+  bool agreedToThirdParty = false;
+
+  String userName = "유저"; // Replace with actual user name
+
+  void updateAll(bool? value) {
+    setState(() {
+      agreedToAll = value ?? false;
+      agreedToService = value ?? false;
+      agreedToPrivacy = value ?? false;
+      isOlderThen14 = value ?? false;
+      agreedToThirdParty = value ?? false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('이용 약관')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              "$userName 님, 반갑습니다!",
+              style: AppTextStyles.titleMedium(context, color: Colors.black),
+            ),
+            SizedBox(height: 8.0),
+            Text(
+              "Live 서비스 시작을 위해 \n아래 이용 약관을 확인해주세요.",
+              style: AppTextStyles.subtitleMedium(
+                context,
+                color: AppColors.blackBlack4,
+              ),
+            ),
+            SizedBox(height: 16.0),
+            Padding(
+              padding: EdgeInsets.only(
+                left: 4.0,
+                right: 0,
+                top: 12.0,
+                bottom: 12.0,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text("전체 동의", style: AppTextStyles.bodyMedium(context)),
+                  Checkbox(value: agreedToAll, onChanged: updateAll),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/terms/terms_screen.dart
+++ b/lib/screens/terms/terms_screen.dart
@@ -1,28 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:live_frontend/screens/terms/widgets/term.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 
-class TermsScreen extends StatefulWidget {
-  @override
-  _TermsScreenState createState() => _TermsScreenState();
+class Agreement {
+  final String label;
+  bool agreed;
+
+  Agreement(this.label, {this.agreed = false});
 }
 
-class _TermsScreenState extends State<TermsScreen> {
+class TermsScreen extends StatefulWidget {
+  @override
+  TermsScreenState createState() => TermsScreenState();
+}
+
+class TermsScreenState extends State<TermsScreen> {
   bool agreedToAll = false;
-  bool agreedToService = false;
-  bool agreedToPrivacy = false;
-  bool isOlderThen14 = false;
-  bool agreedToThirdParty = false;
 
   String userName = "유저"; // Replace with actual user name
+
+  List<Agreement> terms = [
+    Agreement("서비스 이용 약관 (필수)"),
+    Agreement("개인정보 처리 방침 (필수)"),
+    Agreement("14세 이상 확인 (필수)"),
+    Agreement("제3자 정보 제공 동의 (선택)"),
+  ];
 
   void updateAll(bool? value) {
     setState(() {
       agreedToAll = value ?? false;
-      agreedToService = value ?? false;
-      agreedToPrivacy = value ?? false;
-      isOlderThen14 = value ?? false;
-      agreedToThirdParty = value ?? false;
+      terms =
+          terms
+              .map((term) => Agreement(term.label, agreed: agreedToAll))
+              .toList();
     });
   }
 
@@ -31,37 +42,113 @@ class _TermsScreenState extends State<TermsScreen> {
     return Scaffold(
       appBar: AppBar(title: Text('이용 약관')),
       body: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: EdgeInsets.only(
+          left: 20.0,
+          right: 8.0,
+          top: 4.0,
+          bottom: 40.0,
+        ),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
-              "$userName 님, 반갑습니다!",
-              style: AppTextStyles.titleMedium(context, color: Colors.black),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "$userName 님, 반갑습니다!",
+                  style: AppTextStyles.titleMedium(
+                    context,
+                    color: Colors.black,
+                  ),
+                ),
+                SizedBox(height: 8.0),
+                Text(
+                  "Live 서비스 시작을 위해 \n아래 이용 약관을 확인해주세요.",
+                  style: AppTextStyles.subtitleMedium(
+                    context,
+                    color: AppColors.blackBlack4,
+                  ),
+                ),
+                SizedBox(height: 44.0),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      "전체 동의",
+                      style: AppTextStyles.subtitleMedium(
+                        context,
+                        color: AppColors.blackBlack3,
+                      ),
+                    ),
+                    SizedBox(
+                      height: 48,
+                      width: 48,
+                      child: Transform.scale(
+                        scale: 32 / 18,
+                        child: Checkbox(
+                          value: agreedToAll,
+                          onChanged: updateAll,
+                          activeColor: AppColors.greenNormal,
+                          checkColor: Colors.white,
+                          shape: const CircleBorder(
+                            side: BorderSide(color: AppColors.greenNormal),
+                          ),
+                          visualDensity: VisualDensity.compact,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 16.0),
+                Divider(color: AppColors.greenLightActive, thickness: 1.0),
+                SizedBox(height: 12.0),
+                Column(
+                  children:
+                      terms.map((term) {
+                        return Term(
+                          title: term.label,
+                          description: "자세히 보기",
+                          isChecked: term.agreed,
+                          onChanged: (value) {
+                            setState(() {
+                              term.agreed = value ?? false;
+                              agreedToAll = terms.every((t) => t.agreed);
+                            });
+                          },
+                        );
+                      }).toList(),
+                ),
+              ],
             ),
-            SizedBox(height: 8.0),
-            Text(
-              "Live 서비스 시작을 위해 \n아래 이용 약관을 확인해주세요.",
-              style: AppTextStyles.subtitleMedium(
-                context,
-                color: AppColors.blackBlack4,
-              ),
-            ),
-            SizedBox(height: 16.0),
             Padding(
-              padding: EdgeInsets.only(
-                left: 4.0,
-                right: 0,
-                top: 12.0,
-                bottom: 12.0,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text("전체 동의", style: AppTextStyles.bodyMedium(context)),
-                  Checkbox(value: agreedToAll, onChanged: updateAll),
-                ],
+              padding: EdgeInsets.only(right: 12.0),
+              child: ElevatedButton(
+                onPressed:
+                    agreedToAll
+                        ? () {
+                          // Handle agreement submission
+                          //   Navigator.pop(context);
+                        }
+                        : null,
+                style: ElevatedButton.styleFrom(
+                  minimumSize: Size(double.infinity, 48),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  backgroundColor:
+                      agreedToAll
+                          ? AppColors.greenNormal
+                          : AppColors.blackBlack2,
+                ),
+                child: Text(
+                  "동의하고 시작하기",
+                  style: AppTextStyles.subtitleSemibold(
+                    context,
+                    color: Colors.white,
+                  ),
+                ),
               ),
             ),
           ],

--- a/lib/screens/terms/widgets/term.dart
+++ b/lib/screens/terms/widgets/term.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+import 'package:live_frontend/theme/app_text_styles.dart';
+
+class Term extends StatelessWidget {
+  final String title;
+  final String description;
+  final bool isChecked;
+  final ValueChanged<bool?> onChanged;
+
+  const Term({
+    Key? key,
+    required this.title,
+    required this.description,
+    required this.isChecked,
+    required this.onChanged,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(
+          title,
+          style: AppTextStyles.subtitleMedium(
+            context,
+            color: AppColors.blackBlack3,
+            decoration: TextDecoration.underline,
+          ),
+        ),
+        SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: Transform.scale(
+              scale: 24 / 18, // 시각적으로 24x24로 키움
+              child: Checkbox(
+                value: isChecked,
+                onChanged: onChanged,
+                activeColor: AppColors.greenNormal,
+                checkColor: Colors.white,
+                shape: const CircleBorder(),
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap, // ✅ 필수
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [x]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 약관 동의 페이지를 만들었습니다. 임시구현 상태이며, 이후 클릭 시 각각의 약관 페이지로 이동하는 것, api 연동 등이 남아있습니다. 
> <img width="295" alt="스크린샷 2025-06-07 오전 12 20 00" src="https://github.com/user-attachments/assets/ccfbb04d-7bec-4ca9-b314-5bc58cbfc6ca" />


&nbsp;
### 🔍 작업 상세 내용

- [x] 약관 동의 페이지
- [x] 전체 동의 기능
- [x] 전체 동의해야 버튼 클릭 가능

&nbsp;
### 💬 리뷰어에게 전달할 내용 (선택)

> 1. 지금 black 색상이 디자인 시스템에서 잘못 되어있는 게 있어 수정이 필요합니다.
> 2. pr 올리기 직전에 버튼 색상이 잘못되어있는 것을 지금 발견하였습니다..... 이후 수정 예정입니다.

&nbsp;
### 🔗 관련 이슈 (선택)

- Resolves: #이슈번호
- Ref: #참고이슈
- Related to: #12