### PR TITLE
Feat: 미션 추가 화면 구현

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -36,6 +36,9 @@ class MyApp extends ConsumerWidget {
             checkboxTheme: CheckboxThemeData(
               side: const BorderSide(color: AppColors.greenNormal),
             ),
+            switchTheme: SwitchThemeData(
+              trackOutlineColor: WidgetStateProperty.all(AppColors.blackBlack2),
+            ),
             colorScheme: saeipColorScheme,
             useMaterial3: true,
           ),

--- a/lib/models/my_mission_model.dart
+++ b/lib/models/my_mission_model.dart
@@ -75,7 +75,7 @@ class MyMissionModel {
   /// 예시: ["08:30", "21:00"] (24시간 기준 권장)
   final String scheduledTime;
 
-  final List<RepeatDay> repeatDays;
+  final RepeatDay repeatDay;
 
   const MyMissionModel({
     required this.userMissionId,
@@ -83,7 +83,7 @@ class MyMissionModel {
     required this.missionTitle,
     required this.missionStatus,
     required this.scheduledTime,
-    required this.repeatDays,
+    required this.repeatDay,
   });
 
   factory MyMissionModel.fromJson(Map<String, dynamic> json) =>
@@ -97,7 +97,7 @@ class MyMissionModel {
     DateTime? startDate,
     DateTime? endDate,
     String? scheduledTime,
-    List<RepeatDay>? repeatDays,
+    RepeatDay? repeatDay,
     bool? active,
   }) {
     return MyMissionModel(
@@ -106,25 +106,25 @@ class MyMissionModel {
       missionTitle: missionTitle ?? this.missionTitle,
       missionStatus: missionStatus,
       scheduledTime: scheduledTime ?? this.scheduledTime,
-      repeatDays: repeatDays ?? this.repeatDays,
+      repeatDay: repeatDay ?? this.repeatDay,
     );
   }
 }
 
 @JsonSerializable()
 class MyMissionAddModel {
-  final String? missionTitle;
-  final DateTime? startDate;
-  final DateTime? endDate;
-  final String? scheduledTime;
-  final List<RepeatDay>? repeatDays;
+  String? missionTitle;
+  DateTime? startDate;
+  DateTime? endDate;
+  String? scheduledTime;
+  RepeatDay? repeatDay;
 
   MyMissionAddModel({
     this.missionTitle,
     this.startDate,
     this.endDate,
     this.scheduledTime,
-    this.repeatDays,
+    this.repeatDay,
   });
 
   factory MyMissionAddModel.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/my_mission_model.dart
+++ b/lib/models/my_mission_model.dart
@@ -22,25 +22,37 @@ enum RepeatDay {
   saturday,
   @JsonValue('SUNDAY')
   sunday,
+  @JsonValue('EVERYDAY')
+  everyday,
+  @JsonValue('WEEKDAYS')
+  weekdays,
+  @JsonValue('WEEKEND')
+  weekend,
 }
 
 extension RepeatDayLabel on RepeatDay {
   String get label {
     switch (this) {
       case RepeatDay.monday:
-        return '월요일';
+        return '월요일마다';
       case RepeatDay.tuesday:
-        return '화요일';
+        return '화요일마다';
       case RepeatDay.wednesday:
-        return '수요일';
+        return '수요일마다';
       case RepeatDay.thursday:
-        return '목요일';
+        return '목요일마다';
       case RepeatDay.friday:
-        return '금요일';
+        return '금요일마다';
       case RepeatDay.saturday:
-        return '토요일';
+        return '토요일마다';
       case RepeatDay.sunday:
-        return '일요일';
+        return '일요일마다';
+      case RepeatDay.everyday:
+        return '매일마다';
+      case RepeatDay.weekdays:
+        return '평일마다';
+      case RepeatDay.weekend:
+        return '주말마다';
     }
   }
 }
@@ -97,4 +109,26 @@ class MyMissionModel {
       repeatDays: repeatDays ?? this.repeatDays,
     );
   }
+}
+
+@JsonSerializable()
+class MyMissionAddModel {
+  final String? missionTitle;
+  final DateTime? startDate;
+  final DateTime? endDate;
+  final String? scheduledTime;
+  final List<RepeatDay>? repeatDays;
+
+  MyMissionAddModel({
+    this.missionTitle,
+    this.startDate,
+    this.endDate,
+    this.scheduledTime,
+    this.repeatDays,
+  });
+
+  factory MyMissionAddModel.fromJson(Map<String, dynamic> json) =>
+      _$MyMissionAddModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MyMissionAddModelToJson(this);
 }

--- a/lib/models/my_mission_model.dart
+++ b/lib/models/my_mission_model.dart
@@ -127,6 +127,29 @@ class MyMissionAddModel {
     this.repeatDay,
   });
 
+  static DateTime parseTime(String? time) {
+    if (time == null || time.isEmpty) {
+      return DateTime.now();
+    }
+    final parts = time.split(':');
+    if (parts.length != 2) {
+      throw FormatException('Invalid time format');
+    }
+    final hours = int.tryParse(parts[0]);
+    final minutes = int.tryParse(parts[1]);
+    if (hours == null || minutes == null) {
+      throw FormatException('Invalid time format');
+    }
+    return DateTime(0, 0, 0, hours, minutes);
+  }
+
+  static String formatTime(DateTime? dateTime) {
+    if (dateTime == null) {
+      return '00:00';
+    }
+    return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+
   factory MyMissionAddModel.fromJson(Map<String, dynamic> json) =>
       _$MyMissionAddModelFromJson(json);
 

--- a/lib/models/my_mission_model.dart
+++ b/lib/models/my_mission_model.dart
@@ -155,3 +155,25 @@ class MyMissionAddModel {
 
   Map<String, dynamic> toJson() => _$MyMissionAddModelToJson(this);
 }
+
+@JsonSerializable()
+class MyMissionAddPayloadModel {
+  final String missionTitle;
+  final String? startDate;
+  final String? endDate;
+  final String? scheduledTime;
+  final RepeatDay? repeatDay;
+
+  MyMissionAddPayloadModel({
+    required this.missionTitle,
+    this.startDate,
+    this.endDate,
+    this.scheduledTime,
+    this.repeatDay,
+  });
+
+  factory MyMissionAddPayloadModel.fromJson(Map<String, dynamic> json) =>
+      _$MyMissionAddPayloadModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MyMissionAddPayloadModelToJson(this);
+}

--- a/lib/models/my_mission_model.g.dart
+++ b/lib/models/my_mission_model.g.dart
@@ -13,21 +13,18 @@ MyMissionModel _$MyMissionModelFromJson(Map<String, dynamic> json) =>
       missionTitle: json['missionTitle'] as String,
       missionStatus: $enumDecode(_$MissionStatusEnumMap, json['missionStatus']),
       scheduledTime: json['scheduledTime'] as String,
-      repeatDays: (json['repeatDays'] as List<dynamic>)
-          .map((e) => $enumDecode(_$RepeatDayEnumMap, e))
-          .toList(),
+      repeatDay: $enumDecode(_$RepeatDayEnumMap, json['repeatDay']),
     );
 
-Map<String, dynamic> _$MyMissionModelToJson(
-  MyMissionModel instance,
-) => <String, dynamic>{
-  'userMissionId': instance.userMissionId,
-  'missionType': _$MissionTypeEnumMap[instance.missionType]!,
-  'missionTitle': instance.missionTitle,
-  'missionStatus': _$MissionStatusEnumMap[instance.missionStatus]!,
-  'scheduledTime': instance.scheduledTime,
-  'repeatDays': instance.repeatDays.map((e) => _$RepeatDayEnumMap[e]!).toList(),
-};
+Map<String, dynamic> _$MyMissionModelToJson(MyMissionModel instance) =>
+    <String, dynamic>{
+      'userMissionId': instance.userMissionId,
+      'missionType': _$MissionTypeEnumMap[instance.missionType]!,
+      'missionTitle': instance.missionTitle,
+      'missionStatus': _$MissionStatusEnumMap[instance.missionStatus]!,
+      'scheduledTime': instance.scheduledTime,
+      'repeatDay': _$RepeatDayEnumMap[instance.repeatDay]!,
+    };
 
 const _$MissionTypeEnumMap = {
   MissionType.my: 'MY',
@@ -65,9 +62,7 @@ MyMissionAddModel _$MyMissionAddModelFromJson(Map<String, dynamic> json) =>
           ? null
           : DateTime.parse(json['endDate'] as String),
       scheduledTime: json['scheduledTime'] as String?,
-      repeatDays: (json['repeatDays'] as List<dynamic>?)
-          ?.map((e) => $enumDecode(_$RepeatDayEnumMap, e))
-          .toList(),
+      repeatDay: $enumDecodeNullable(_$RepeatDayEnumMap, json['repeatDay']),
     );
 
 Map<String, dynamic> _$MyMissionAddModelToJson(MyMissionAddModel instance) =>
@@ -76,7 +71,5 @@ Map<String, dynamic> _$MyMissionAddModelToJson(MyMissionAddModel instance) =>
       'startDate': instance.startDate?.toIso8601String(),
       'endDate': instance.endDate?.toIso8601String(),
       'scheduledTime': instance.scheduledTime,
-      'repeatDays': instance.repeatDays
-          ?.map((e) => _$RepeatDayEnumMap[e]!)
-          .toList(),
+      'repeatDay': _$RepeatDayEnumMap[instance.repeatDay],
     };

--- a/lib/models/my_mission_model.g.dart
+++ b/lib/models/my_mission_model.g.dart
@@ -50,4 +50,33 @@ const _$RepeatDayEnumMap = {
   RepeatDay.friday: 'FRIDAY',
   RepeatDay.saturday: 'SATURDAY',
   RepeatDay.sunday: 'SUNDAY',
+  RepeatDay.everyday: 'EVERYDAY',
+  RepeatDay.weekdays: 'WEEKDAYS',
+  RepeatDay.weekend: 'WEEKEND',
 };
+
+MyMissionAddModel _$MyMissionAddModelFromJson(Map<String, dynamic> json) =>
+    MyMissionAddModel(
+      missionTitle: json['missionTitle'] as String?,
+      startDate: json['startDate'] == null
+          ? null
+          : DateTime.parse(json['startDate'] as String),
+      endDate: json['endDate'] == null
+          ? null
+          : DateTime.parse(json['endDate'] as String),
+      scheduledTime: json['scheduledTime'] as String?,
+      repeatDays: (json['repeatDays'] as List<dynamic>?)
+          ?.map((e) => $enumDecode(_$RepeatDayEnumMap, e))
+          .toList(),
+    );
+
+Map<String, dynamic> _$MyMissionAddModelToJson(MyMissionAddModel instance) =>
+    <String, dynamic>{
+      'missionTitle': instance.missionTitle,
+      'startDate': instance.startDate?.toIso8601String(),
+      'endDate': instance.endDate?.toIso8601String(),
+      'scheduledTime': instance.scheduledTime,
+      'repeatDays': instance.repeatDays
+          ?.map((e) => _$RepeatDayEnumMap[e]!)
+          .toList(),
+    };

--- a/lib/models/my_mission_model.g.dart
+++ b/lib/models/my_mission_model.g.dart
@@ -73,3 +73,23 @@ Map<String, dynamic> _$MyMissionAddModelToJson(MyMissionAddModel instance) =>
       'scheduledTime': instance.scheduledTime,
       'repeatDay': _$RepeatDayEnumMap[instance.repeatDay],
     };
+
+MyMissionAddPayloadModel _$MyMissionAddPayloadModelFromJson(
+  Map<String, dynamic> json,
+) => MyMissionAddPayloadModel(
+  missionTitle: json['missionTitle'] as String,
+  startDate: json['startDate'] as String?,
+  endDate: json['endDate'] as String?,
+  scheduledTime: json['scheduledTime'] as String?,
+  repeatDay: $enumDecodeNullable(_$RepeatDayEnumMap, json['repeatDay']),
+);
+
+Map<String, dynamic> _$MyMissionAddPayloadModelToJson(
+  MyMissionAddPayloadModel instance,
+) => <String, dynamic>{
+  'missionTitle': instance.missionTitle,
+  'startDate': instance.startDate,
+  'endDate': instance.endDate,
+  'scheduledTime': instance.scheduledTime,
+  'repeatDay': _$RepeatDayEnumMap[instance.repeatDay],
+};

--- a/lib/routers/app_router.dart
+++ b/lib/routers/app_router.dart
@@ -6,6 +6,7 @@ import 'package:live_frontend/screens/forum/forum_screen.dart';
 import 'package:live_frontend/screens/home/clover-record/mission_record_screen.dart';
 import 'package:live_frontend/screens/home/execute/execute_photo_mission_screen.dart';
 import 'package:live_frontend/screens/home/execute/execute_timer_mission_screen.dart';
+import 'package:live_frontend/screens/home/my-mission-add/my_mission_add_screen.dart';
 import 'package:live_frontend/screens/map/map_screen.dart';
 import 'package:live_frontend/screens/mypage/mypage_screen.dart';
 import 'package:live_frontend/screens/statistics/statistics_screen.dart';
@@ -108,6 +109,13 @@ final routerProvider = Provider<GoRouter>((ref) {
             path: 'execute/photo_mission',
             builder: (context, state) =>
                 ExecutePhotoMissionScreen(id: state.extra as int),
+          ),
+          GoRoute(
+            name: 'my_mission_add',
+            path: 'my_mission_add',
+            builder: (context, state) {
+              return MyMissionAddScreen();
+            },
           ),
         ],
       ),

--- a/lib/routers/app_router.dart
+++ b/lib/routers/app_router.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/screens/404/not_found_screen.dart';
 import 'package:live_frontend/screens/forum/forum_screen.dart';
 import 'package:live_frontend/screens/home/clover-record/mission_record_screen.dart';
 import 'package:live_frontend/screens/home/execute/execute_photo_mission_screen.dart';
 import 'package:live_frontend/screens/home/execute/execute_timer_mission_screen.dart';
 import 'package:live_frontend/screens/home/my-mission-add/my_mission_add_screen.dart';
+import 'package:live_frontend/screens/home/my-mission-add/repeat/repeat_screen.dart';
 import 'package:live_frontend/screens/map/map_screen.dart';
 import 'package:live_frontend/screens/mypage/mypage_screen.dart';
 import 'package:live_frontend/screens/statistics/statistics_screen.dart';
@@ -116,6 +118,15 @@ final routerProvider = Provider<GoRouter>((ref) {
             builder: (context, state) {
               return MyMissionAddScreen();
             },
+            routes: [
+              GoRoute(
+                path: 'repeat',
+                name: 'repeat',
+                builder: (context, state) {
+                  return RepeatScreen(initial: state.extra as RepeatDay?);
+                },
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -47,7 +47,7 @@ List<MyMissionModel> myMissionList = [
     missionTitle: 'My Mission 1',
     missionStatus: MissionStatus.started,
     scheduledTime: '08:00',
-    repeatDays: [RepeatDay.monday, RepeatDay.wednesday, RepeatDay.friday],
+    repeatDay: RepeatDay.monday,
   ),
   MyMissionModel(
     userMissionId: 2,
@@ -55,7 +55,7 @@ List<MyMissionModel> myMissionList = [
     missionTitle: 'My Mission 2',
     missionStatus: MissionStatus.completed,
     scheduledTime: '10:00',
-    repeatDays: [RepeatDay.tuesday, RepeatDay.thursday],
+    repeatDay: RepeatDay.tuesday,
   ),
   MyMissionModel(
     userMissionId: 3,
@@ -63,7 +63,7 @@ List<MyMissionModel> myMissionList = [
     missionTitle: 'My Mission 3',
     missionStatus: MissionStatus.started,
     scheduledTime: '22:00',
-    repeatDays: [RepeatDay.saturday, RepeatDay.sunday],
+    repeatDay: RepeatDay.saturday,
   ),
 ];
 

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -4,12 +4,14 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:live_frontend/models/my_mission_model.dart';
+import 'package:live_frontend/screens/home/my-mission-add/widget/selection_button.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/selection_tile.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/date_picker.dart';
 import 'package:time_picker_spinner/time_picker_spinner.dart';
+import 'package:go_router/go_router.dart';
 
 class MyMissionAddScreen extends StatefulWidget {
   const MyMissionAddScreen({super.key});
@@ -151,7 +153,7 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                 ),
               ),
               Gap(16.h),
-              SelectionTile(
+              SelectionButton(
                 title: '반복',
                 selected: _mission.repeatDay?.label,
                 include: _included[3],
@@ -160,10 +162,17 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                     _included[3] = value;
                   });
                 },
-                child: Text(
-                  _mission.repeatDay?.label ?? '선택 안함',
-                  style: AppTextStyles.bodyRegular(context),
-                ),
+                onPressed: () async {
+                  final result = await context.pushNamed(
+                    'repeat',
+                    extra: _mission.repeatDay,
+                  );
+                  if (result != null && result is RepeatDay) {
+                    setState(() {
+                      _mission.repeatDay = result;
+                    });
+                  }
+                },
               ),
             ],
           ),

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:jiffy/jiffy.dart';
 import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/selection_tile.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
+import 'package:live_frontend/screens/home/my-mission-add/widget/date_picker.dart';
 
 class MyMissionAddScreen extends StatefulWidget {
   const MyMissionAddScreen({super.key});
@@ -16,24 +18,20 @@ class MyMissionAddScreen extends StatefulWidget {
 }
 
 class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
-  final MyMissionAddModel _mission = MyMissionAddModel(
-    missionTitle: null,
-    startDate: null,
-    endDate: null,
-    scheduledTime: null,
-    repeatDays: null,
-  );
-  // 선택 여부
-  final List<bool> _included = [
-    false, // 시작일
-    false, // 종료일
-    false, // 시간
-    false, // 반복
-  ];
+  late MyMissionAddModel _mission;
+  late List<bool> _included;
 
   @override
   void initState() {
     super.initState();
+    _mission = MyMissionAddModel(
+      missionTitle: null,
+      startDate: null,
+      endDate: null,
+      scheduledTime: null,
+      repeatDay: null,
+    );
+    _included = [false, false, false, false]; // 초기 선택 여부 설정
   }
 
   @override
@@ -44,7 +42,7 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
         child: Container(
           color: AppColors.blackBlack0,
           padding: EdgeInsets.only(left: 16.w, right: 16.w, bottom: 40.h),
-          child: Column(
+          child: ListView(
             children: [
               TextField(
                 style: AppTextStyles.bodyRegular(context, color: Colors.black),
@@ -74,24 +72,47 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
               Gap(16.h),
               SelectionTile(
                 title: '시작일',
-                selected: _mission.startDate?.toString(),
+                // jiffy 사용해서 m월 d일로 표기하기. 오늘이면 오늘로 표기
+                selected: _dateToFormat(_mission.startDate),
                 include: _included[0],
                 onToggle: (value) {
                   setState(() {
                     _included[0] = value;
                   });
                 },
+                child: DatePicker(
+                  type: DatePickerType.start,
+                  startDate: _mission.startDate,
+                  endDate: _mission.endDate,
+                  selectedDate: _mission.startDate,
+                  onDateSelected: (date) {
+                    setState(() {
+                      _mission.startDate = date;
+                    });
+                  },
+                ),
               ),
               Gap(16.h),
               SelectionTile(
                 title: '종료일',
-                selected: _mission.endDate?.toString(),
+                selected: _dateToFormat(_mission.endDate),
                 include: _included[1],
                 onToggle: (value) {
                   setState(() {
                     _included[1] = value;
                   });
                 },
+                child: DatePicker(
+                  type: DatePickerType.end,
+                  startDate: _mission.startDate,
+                  endDate: _mission.endDate,
+                  selectedDate: _mission.endDate,
+                  onDateSelected: (date) {
+                    setState(() {
+                      _mission.endDate = date;
+                    });
+                  },
+                ),
               ),
               Gap(16.h),
               SelectionTile(
@@ -103,22 +124,41 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                     _included[2] = value;
                   });
                 },
+                child: Text(
+                  _mission.scheduledTime ?? '선택 안함',
+                  style: AppTextStyles.bodyRegular(context),
+                ),
               ),
               Gap(16.h),
               SelectionTile(
                 title: '반복',
-                selected: _mission.repeatDays?.map((e) => e.label).join(', '),
+                selected: _mission.repeatDay?.label,
                 include: _included[3],
                 onToggle: (value) {
                   setState(() {
                     _included[3] = value;
                   });
                 },
+                child: Text(
+                  _mission.repeatDay?.label ?? '선택 안함',
+                  style: AppTextStyles.bodyRegular(context),
+                ),
               ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  String? _dateToFormat(DateTime? date) {
+    if (date == null) {
+      return null;
+    } else if (Jiffy.parseFromDateTime(
+      date,
+    ).isSame(Jiffy.now(), unit: Unit.day)) {
+      return '오늘';
+    }
+    return Jiffy.parseFromDateTime(date).format(pattern: 'M월 d일');
   }
 }

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -11,6 +11,7 @@ import 'package:live_frontend/theme/app_text_styles.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/date_picker.dart';
 import 'package:live_frontend/widgets/saeip_button.dart';
+import 'package:live_frontend/widgets/utils/show_saeip_toast.dart';
 import 'package:time_picker_spinner/time_picker_spinner.dart';
 import 'package:go_router/go_router.dart';
 
@@ -25,6 +26,9 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
   late MyMissionAddModel _mission;
   late List<bool> _included;
 
+  // 1) TextField controller로 값 관리
+  late final TextEditingController _titleController;
+
   @override
   void initState() {
     super.initState();
@@ -35,7 +39,92 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
       scheduledTime: null,
       repeatDay: null,
     );
-    _included = [false, false, false, false]; // 초기 선택 여부 설정
+    _included = [false, false, false, false]; // 시작일, 종료일, 시간, 반복
+    _titleController = TextEditingController(text: _mission.missionTitle ?? '');
+    _titleController.addListener(() {
+      _mission.missionTitle = _titleController.text;
+    });
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  // 3) _included에 따라 실제 존재하는지 판단하는 getter
+  bool get _effectiveStartPresent => _included[0] && _mission.startDate != null;
+  bool get _effectiveEndPresent => _included[1] && _mission.endDate != null;
+
+  void _showError(String message) {
+    SaeipToastController.showMessage(context, message);
+  }
+
+  // 2) 버튼 클릭 시 validation
+  bool _validateBeforeSave() {
+    final title = _titleController.text.trim();
+    if (title.length < 2) {
+      _showError('제목을 두 글자 이상 입력해주세요.');
+      return false;
+    }
+
+    // 시작/종료는 각각 _included가 false면 "없음"으로 간주
+    // 둘 중 하나만 존재하면 에러
+    if (_effectiveStartPresent != _effectiveEndPresent) {
+      if (!_effectiveStartPresent && _effectiveEndPresent) {
+        _showError('시작일을 선택해주세요.');
+      } else if (_effectiveStartPresent && !_effectiveEndPresent) {
+        _showError('종료일을 선택해주세요.');
+      }
+      return false;
+    }
+    if (_included[0] && _mission.startDate == null) {
+      _showError('시작일을 선택해주세요.');
+      return false;
+    }
+    if (_included[1] && _mission.endDate == null) {
+      _showError('종료일을 선택해주세요.');
+      return false;
+    }
+    if (_included[2] && _mission.scheduledTime == null) {
+      _showError('시간을 선택해주세요.');
+      return false;
+    }
+    if (_included[3] && _mission.repeatDay == null) {
+      _showError('반복 설정을 선택해주세요.');
+      return false;
+    }
+
+    // 시작일이 종료일보다 늦으면 에러
+    if (_effectiveStartPresent &&
+        _effectiveEndPresent &&
+        _mission.startDate!.isAfter(_mission.endDate!)) {
+      _showError('시작일은 종료일보다 이전이어야 합니다.');
+      return false;
+    }
+    return true;
+  }
+
+  void _onSavePressed() {
+    if (!_validateBeforeSave()) return;
+    MyMissionAddPayloadModel payload = MyMissionAddPayloadModel(
+      missionTitle: _titleController.text.trim(),
+      startDate: _mission.startDate != null && _included[0]
+          ? Jiffy.parseFromDateTime(
+              _mission.startDate!,
+            ).format(pattern: 'yyyy-MM-DD')
+          : null,
+      endDate: _mission.endDate != null && _included[1]
+          ? Jiffy.parseFromDateTime(
+              _mission.endDate!,
+            ).format(pattern: 'yyyy-MM-DD')
+          : null,
+      scheduledTime: _included[2] ? _mission.scheduledTime : null,
+      repeatDay: _included[3] ? _mission.repeatDay : null,
+    );
+
+    // 로그로 json 출력하기
+    debugPrint(payload.toJson().toString());
   }
 
   @override
@@ -52,7 +141,7 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
         child: SizedBox(
           width: double.infinity,
           height: 48.h,
-          child: SaeipButton(text: '저장', onPressed: () {}),
+          child: SaeipButton(text: '저장', onPressed: _onSavePressed),
         ),
       ),
       body: SafeArea(
@@ -61,7 +150,9 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
           padding: EdgeInsets.only(left: 16.w, right: 16.w, bottom: 120.h),
           child: ListView(
             children: [
+              // 1) controller 연결된 TextField
               TextField(
+                controller: _titleController,
                 style: AppTextStyles.bodyRegular(context, color: Colors.black),
                 decoration: InputDecoration(
                   hintText: '제목',
@@ -72,14 +163,14 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(4.r),
                     borderSide: BorderSide(
-                      color: AppColors.greenLightActive, // 비활성(포커스X)일 때 색상
+                      color: AppColors.greenLightActive,
                       width: 1.w,
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(4.r),
                     borderSide: BorderSide(
-                      color: AppColors.greenLightActive, // 포커스일 때 색상
+                      color: AppColors.greenLightActive,
                       width: 1.w,
                     ),
                   ),
@@ -94,6 +185,7 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                 onToggle: (value) {
                   setState(() {
                     _included[0] = value;
+                    _included[1] = value;
                   });
                 },
                 child: DatePicker(
@@ -115,6 +207,7 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                 include: _included[1],
                 onToggle: (value) {
                   setState(() {
+                    _included[0] = value;
                     _included[1] = value;
                   });
                 },

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:live_frontend/screens/home/my-mission-add/widget/selection_tile.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+import 'package:live_frontend/theme/app_text_styles.dart';
+import 'package:live_frontend/widgets/saeip_app_bar.dart';
+
+class MyMissionAddScreen extends StatefulWidget {
+  const MyMissionAddScreen({super.key});
+
+  @override
+  State<MyMissionAddScreen> createState() => _MyMissionAddScreenState();
+}
+
+class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: SaeipAppBar(title: '마이 미션 추가'),
+      body: SafeArea(
+        child: Container(
+          color: AppColors.blackBlack0,
+          padding: EdgeInsets.only(left: 16.w, right: 16.w, bottom: 40.h),
+          child: Column(
+            children: [
+              TextField(
+                style: AppTextStyles.bodyRegular(context, color: Colors.black),
+                decoration: InputDecoration(
+                  hintText: '제목',
+                  hintStyle: AppTextStyles.bodyRegular(
+                    context,
+                    color: AppColors.blackBlack4,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(4.r),
+                    borderSide: BorderSide(
+                      color: AppColors.greenLightActive, // 비활성(포커스X)일 때 색상
+                      width: 1.w,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(4.r),
+                    borderSide: BorderSide(
+                      color: AppColors.greenLightActive, // 포커스일 때 색상
+                      width: 1.w,
+                    ),
+                  ),
+                ),
+                inputFormatters: [LengthLimitingTextInputFormatter(20)],
+              ),
+              Gap(16.h),
+              SelectionTile(title: '시작일', selected: '2023-01-01'),
+              Gap(16.h),
+              SelectionTile(title: '종료일', selected: '2023-01-01'),
+              Gap(16.h),
+              SelectionTile(title: '시간', selected: '09:00'),
+              Gap(16.h),
+              SelectionTile(title: '반복', selected: '매일'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -9,6 +9,7 @@ import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/date_picker.dart';
+import 'package:time_picker_spinner/time_picker_spinner.dart';
 
 class MyMissionAddScreen extends StatefulWidget {
   const MyMissionAddScreen({super.key});
@@ -72,7 +73,6 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
               Gap(16.h),
               SelectionTile(
                 title: '시작일',
-                // jiffy 사용해서 m월 d일로 표기하기. 오늘이면 오늘로 표기
                 selected: _dateToFormat(_mission.startDate),
                 include: _included[0],
                 onToggle: (value) {
@@ -116,7 +116,7 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
               ),
               Gap(16.h),
               SelectionTile(
-                title: '시간',
+                title: '시간   ',
                 selected: _mission.scheduledTime,
                 include: _included[2],
                 onToggle: (value) {
@@ -124,9 +124,30 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                     _included[2] = value;
                   });
                 },
-                child: Text(
-                  _mission.scheduledTime ?? '선택 안함',
-                  style: AppTextStyles.bodyRegular(context),
+                child: TimePickerSpinner(
+                  locale: const Locale('en', ''),
+                  time: MyMissionAddModel.parseTime(
+                    _mission.scheduledTime ?? '',
+                  ),
+                  is24HourMode: false,
+                  itemHeight: 70,
+                  spacing: 25,
+                  normalTextStyle: AppTextStyles.bodyMedium(
+                    context,
+                    color: AppColors.blackBlack5,
+                  ),
+                  highlightedTextStyle: AppTextStyles.subtitleMedium(
+                    context,
+                    color: Colors.black,
+                  ),
+                  isForce2Digits: true,
+                  onTimeChange: (time) {
+                    setState(() {
+                      _mission.scheduledTime = MyMissionAddModel.formatTime(
+                        time,
+                      );
+                    });
+                  },
                 ),
               ),
               Gap(16.h),

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/selection_tile.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
@@ -15,6 +16,26 @@ class MyMissionAddScreen extends StatefulWidget {
 }
 
 class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
+  final MyMissionAddModel _mission = MyMissionAddModel(
+    missionTitle: null,
+    startDate: null,
+    endDate: null,
+    scheduledTime: null,
+    repeatDays: null,
+  );
+  // 선택 여부
+  final List<bool> _included = [
+    false, // 시작일
+    false, // 종료일
+    false, // 시간
+    false, // 반복
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -51,13 +72,49 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
                 inputFormatters: [LengthLimitingTextInputFormatter(20)],
               ),
               Gap(16.h),
-              SelectionTile(title: '시작일', selected: '2023-01-01'),
+              SelectionTile(
+                title: '시작일',
+                selected: _mission.startDate?.toString(),
+                include: _included[0],
+                onToggle: (value) {
+                  setState(() {
+                    _included[0] = value;
+                  });
+                },
+              ),
               Gap(16.h),
-              SelectionTile(title: '종료일', selected: '2023-01-01'),
+              SelectionTile(
+                title: '종료일',
+                selected: _mission.endDate?.toString(),
+                include: _included[1],
+                onToggle: (value) {
+                  setState(() {
+                    _included[1] = value;
+                  });
+                },
+              ),
               Gap(16.h),
-              SelectionTile(title: '시간', selected: '09:00'),
+              SelectionTile(
+                title: '시간',
+                selected: _mission.scheduledTime,
+                include: _included[2],
+                onToggle: (value) {
+                  setState(() {
+                    _included[2] = value;
+                  });
+                },
+              ),
               Gap(16.h),
-              SelectionTile(title: '반복', selected: '매일'),
+              SelectionTile(
+                title: '반복',
+                selected: _mission.repeatDays?.map((e) => e.label).join(', '),
+                include: _included[3],
+                onToggle: (value) {
+                  setState(() {
+                    _included[3] = value;
+                  });
+                },
+              ),
             ],
           ),
         ),

--- a/lib/screens/home/my-mission-add/my_mission_add_screen.dart
+++ b/lib/screens/home/my-mission-add/my_mission_add_screen.dart
@@ -10,6 +10,7 @@ import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
 import 'package:live_frontend/screens/home/my-mission-add/widget/date_picker.dart';
+import 'package:live_frontend/widgets/saeip_button.dart';
 import 'package:time_picker_spinner/time_picker_spinner.dart';
 import 'package:go_router/go_router.dart';
 
@@ -41,10 +42,23 @@ class _MyMissionAddScreenState extends State<MyMissionAddScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: SaeipAppBar(title: '마이 미션 추가'),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: Padding(
+        padding: EdgeInsets.only(
+          left: 16.w,
+          right: 16.w,
+          bottom: 24.h,
+        ), // 기본 하단 패딩이 16임
+        child: SizedBox(
+          width: double.infinity,
+          height: 48.h,
+          child: SaeipButton(text: '저장', onPressed: () {}),
+        ),
+      ),
       body: SafeArea(
         child: Container(
           color: AppColors.blackBlack0,
-          padding: EdgeInsets.only(left: 16.w, right: 16.w, bottom: 40.h),
+          padding: EdgeInsets.only(left: 16.w, right: 16.w, bottom: 120.h),
           child: ListView(
             children: [
               TextField(

--- a/lib/screens/home/my-mission-add/repeat/repeat_screen.dart
+++ b/lib/screens/home/my-mission-add/repeat/repeat_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+import 'package:live_frontend/theme/app_text_styles.dart';
+import 'package:live_frontend/widgets/saeip_app_bar.dart';
+import 'package:live_frontend/models/my_mission_model.dart';
+
+class RepeatScreen extends StatefulWidget {
+  final RepeatDay? initial;
+
+  const RepeatScreen({super.key, this.initial});
+
+  @override
+  State<RepeatScreen> createState() => _RepeatScreenState();
+}
+
+class _RepeatScreenState extends State<RepeatScreen> {
+  late RepeatDay? _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.initial;
+  }
+
+  void _onDone() => Navigator.of(context).pop(_selected);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: SaeipAppBar(
+        title: '반복',
+        actions: [
+          TextButton(
+            onPressed: _onDone,
+            child: TextButton(
+              onPressed: _onDone,
+              style: TextButton.styleFrom(
+                minimumSize: Size(50.w, 40.h),
+                padding: EdgeInsets.symmetric(horizontal: 12.w),
+              ),
+              child: Text(
+                '완료',
+                style: AppTextStyles.bodyMedium(
+                  context,
+                  color: AppColors.greenNormal,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView.separated(
+          itemCount: RepeatDay.values.length,
+          separatorBuilder: (_, __) => const SizedBox.shrink(), // 구분선 제거
+          itemBuilder: (context, index) {
+            final day = RepeatDay.values[index];
+            final label = day.label;
+            final selected = _selected == day;
+            return ListTile(
+              title: Text(label),
+              tileColor: Colors.white,
+              shape: const RoundedRectangleBorder(side: BorderSide.none),
+              trailing: selected
+                  ? const Icon(Icons.check, color: AppColors.greenNormal)
+                  : const SizedBox.shrink(),
+              onTap: () => setState(() => _selected = day),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/my-mission-add/widget/date_picker.dart
+++ b/lib/screens/home/my-mission-add/widget/date_picker.dart
@@ -5,32 +5,35 @@ import 'package:live_frontend/theme/app_colors.dart';
 enum DatePickerType { start, end }
 
 class DatePicker extends StatelessWidget {
-  final DateTime? selectedDate;
-  final ValueChanged<DateTime> onDateSelected;
+  final DatePickerType type;
   final DateTime? startDate;
   final DateTime? endDate;
-  final DatePickerType type;
+  final DateTime? selectedDate;
+  final ValueChanged<DateTime> onDateSelected;
 
   const DatePicker({
     super.key,
-    this.selectedDate,
-    required this.onDateSelected,
+    required this.type,
     this.startDate,
     this.endDate,
-    required this.type,
+    this.selectedDate,
+    required this.onDateSelected,
   });
 
   @override
   Widget build(BuildContext context) {
-    final firstDay = type == DatePickerType.end && startDate != null
-        ? startDate!.add(const Duration(days: 1))
+    // compute valid range
+    final firstDay = (type == DatePickerType.end && startDate != null)
+        ? startDate!
         : DateTime.now();
-    final lastDay = type == DatePickerType.start && endDate != null
-        ? endDate!.subtract(const Duration(days: 1))
+    final lastDay = (type == DatePickerType.start && endDate != null)
+        ? endDate!
         : DateTime.utc(2100, 12, 31);
+
     DateTime focusedDay = selectedDate ?? DateTime.now();
     if (focusedDay.isBefore(firstDay)) focusedDay = firstDay;
     if (focusedDay.isAfter(lastDay)) focusedDay = lastDay;
+
     return TableCalendar(
       firstDay: firstDay,
       lastDay: lastDay,
@@ -38,10 +41,12 @@ class DatePicker extends StatelessWidget {
       calendarFormat: CalendarFormat.month,
       selectedDayPredicate: (day) =>
           selectedDate != null && isSameDay(day, selectedDate),
-      onDaySelected: (selectedDay, focusedDay) {
-        onDateSelected(selectedDay);
-      },
-      headerStyle: HeaderStyle(formatButtonVisible: false, titleCentered: true),
+      onDaySelected: (selectedDay, _) => onDateSelected(selectedDay),
+      headerStyle: const HeaderStyle(
+        formatButtonVisible: false,
+        titleCentered: true,
+      ),
+      availableGestures: AvailableGestures.horizontalSwipe,
       calendarStyle: CalendarStyle(
         todayDecoration: BoxDecoration(
           color: AppColors.greenDarker,

--- a/lib/screens/home/my-mission-add/widget/date_picker.dart
+++ b/lib/screens/home/my-mission-add/widget/date_picker.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+
+enum DatePickerType { start, end }
+
+class DatePicker extends StatelessWidget {
+  final DateTime? selectedDate;
+  final ValueChanged<DateTime> onDateSelected;
+  final DateTime? startDate;
+  final DateTime? endDate;
+  final DatePickerType type;
+
+  const DatePicker({
+    super.key,
+    this.selectedDate,
+    required this.onDateSelected,
+    this.startDate,
+    this.endDate,
+    required this.type,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TableCalendar(
+      firstDay: type == DatePickerType.start
+          ? DateTime.utc(2000, 1, 1)
+          : startDate ?? DateTime.utc(2000, 1, 1),
+      lastDay: type == DatePickerType.end
+          ? DateTime.utc(2100, 12, 31)
+          : endDate ?? DateTime.utc(2100, 12, 31),
+      focusedDay: selectedDate ?? DateTime.now(),
+      calendarFormat: CalendarFormat.month,
+      selectedDayPredicate: (day) =>
+          selectedDate != null && isSameDay(day, selectedDate),
+      onDaySelected: (selectedDay, focusedDay) {
+        onDateSelected(selectedDay);
+      },
+      headerStyle: HeaderStyle(formatButtonVisible: false, titleCentered: true),
+      calendarStyle: CalendarStyle(
+        todayDecoration: BoxDecoration(
+          color: AppColors.greenDarker,
+          shape: BoxShape.circle,
+        ),
+        selectedDecoration: BoxDecoration(
+          color: AppColors.greenNormal,
+          shape: BoxShape.circle,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/my-mission-add/widget/date_picker.dart
+++ b/lib/screens/home/my-mission-add/widget/date_picker.dart
@@ -22,14 +22,19 @@ class DatePicker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final firstDay = type == DatePickerType.end && startDate != null
+        ? startDate!.add(const Duration(days: 1))
+        : DateTime.now();
+    final lastDay = type == DatePickerType.start && endDate != null
+        ? endDate!.subtract(const Duration(days: 1))
+        : DateTime.utc(2100, 12, 31);
+    DateTime focusedDay = selectedDate ?? DateTime.now();
+    if (focusedDay.isBefore(firstDay)) focusedDay = firstDay;
+    if (focusedDay.isAfter(lastDay)) focusedDay = lastDay;
     return TableCalendar(
-      firstDay: type == DatePickerType.start
-          ? DateTime.utc(2000, 1, 1)
-          : startDate ?? DateTime.utc(2000, 1, 1),
-      lastDay: type == DatePickerType.end
-          ? DateTime.utc(2100, 12, 31)
-          : endDate ?? DateTime.utc(2100, 12, 31),
-      focusedDay: selectedDate ?? DateTime.now(),
+      firstDay: firstDay,
+      lastDay: lastDay,
+      focusedDay: focusedDay,
       calendarFormat: CalendarFormat.month,
       selectedDayPredicate: (day) =>
           selectedDate != null && isSameDay(day, selectedDate),

--- a/lib/screens/home/my-mission-add/widget/selection_button.dart
+++ b/lib/screens/home/my-mission-add/widget/selection_button.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+import 'package:live_frontend/theme/app_text_styles.dart';
+
+class SelectionButton extends StatelessWidget {
+  final String title;
+  final String? selected;
+  final bool include;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onPressed;
+
+  const SelectionButton({
+    super.key,
+    required this.title,
+    this.selected,
+    required this.include,
+    required this.onToggle,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(8.r);
+
+    return Material(
+      color: Colors.transparent, // 그림자/고도 없음
+      child: Ink(
+        decoration: BoxDecoration(color: Colors.white, borderRadius: radius),
+        child: InkWell(
+          borderRadius: radius,
+          onTap: onPressed,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: 48.h),
+            child: Padding(
+              padding: EdgeInsetsGeometry.only(left: 16.w, right: 24.w),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          title,
+                          style: AppTextStyles.bodyRegular(
+                            context,
+                            color: Colors.black,
+                          ),
+                        ),
+                        Gap(16.w),
+                        if (selected != null && include)
+                          Flexible(
+                            child: Text(
+                              selected!,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTextStyles.bodyRegular(
+                                context,
+                                color: AppColors.greenNormal,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  // 토글 스위치
+                  Switch(
+                    value: include,
+                    onChanged: onToggle,
+                    inactiveTrackColor: AppColors.blackBlack2,
+                    inactiveThumbColor: Colors.white,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/my-mission-add/widget/selection_tile.dart
+++ b/lib/screens/home/my-mission-add/widget/selection_tile.dart
@@ -9,6 +9,7 @@ class SelectionTile extends StatelessWidget {
   final String? selected;
   final bool include;
   final ValueChanged<bool> onToggle;
+  final Widget child;
 
   const SelectionTile({
     super.key,
@@ -16,6 +17,7 @@ class SelectionTile extends StatelessWidget {
     this.selected,
     required this.include,
     required this.onToggle,
+    required this.child,
   });
 
   @override
@@ -27,7 +29,6 @@ class SelectionTile extends StatelessWidget {
           value: include,
           onChanged: onToggle,
           inactiveTrackColor: AppColors.blackBlack2,
-          // inactiveTrackColor: Colors.transparent, // 검정색 테두리 제거
           inactiveThumbColor: Colors.white,
         ),
         title: Row(
@@ -37,7 +38,7 @@ class SelectionTile extends StatelessWidget {
               style: AppTextStyles.bodyRegular(context, color: Colors.black),
             ),
             Gap(30.w),
-            if (selected != null)
+            if (selected != null && include)
               Text(
                 selected!,
                 style: AppTextStyles.bodyRegular(
@@ -50,7 +51,7 @@ class SelectionTile extends StatelessWidget {
         minTileHeight: 48.h,
         backgroundColor: Colors.white,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.r)),
-        children: <Widget>[ListTile(title: Text('This is tile number 1'))],
+        children: [child],
       ),
     );
   }

--- a/lib/screens/home/my-mission-add/widget/selection_tile.dart
+++ b/lib/screens/home/my-mission-add/widget/selection_tile.dart
@@ -6,15 +6,30 @@ import 'package:live_frontend/theme/app_text_styles.dart';
 
 class SelectionTile extends StatelessWidget {
   final String title;
-  final String selected;
+  final String? selected;
+  final bool include;
+  final ValueChanged<bool> onToggle;
 
-  const SelectionTile({super.key, required this.title, required this.selected});
+  const SelectionTile({
+    super.key,
+    required this.title,
+    this.selected,
+    required this.include,
+    required this.onToggle,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       color: Colors.white,
       child: ExpansionTile(
+        trailing: Switch(
+          value: include,
+          onChanged: onToggle,
+          inactiveTrackColor: AppColors.blackBlack2,
+          // inactiveTrackColor: Colors.transparent, // 검정색 테두리 제거
+          inactiveThumbColor: Colors.white,
+        ),
         title: Row(
           children: [
             Text(
@@ -22,13 +37,14 @@ class SelectionTile extends StatelessWidget {
               style: AppTextStyles.bodyRegular(context, color: Colors.black),
             ),
             Gap(30.w),
-            Text(
-              selected,
-              style: AppTextStyles.bodyRegular(
-                context,
-                color: AppColors.greenNormal,
+            if (selected != null)
+              Text(
+                selected!,
+                style: AppTextStyles.bodyRegular(
+                  context,
+                  color: AppColors.greenNormal,
+                ),
               ),
-            ),
           ],
         ),
         minTileHeight: 48.h,

--- a/lib/screens/home/my-mission-add/widget/selection_tile.dart
+++ b/lib/screens/home/my-mission-add/widget/selection_tile.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:live_frontend/theme/app_colors.dart';
+import 'package:live_frontend/theme/app_text_styles.dart';
+
+class SelectionTile extends StatelessWidget {
+  final String title;
+  final String selected;
+
+  const SelectionTile({super.key, required this.title, required this.selected});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      child: ExpansionTile(
+        title: Row(
+          children: [
+            Text(
+              title,
+              style: AppTextStyles.bodyRegular(context, color: Colors.black),
+            ),
+            Gap(30.w),
+            Text(
+              selected,
+              style: AppTextStyles.bodyRegular(
+                context,
+                color: AppColors.greenNormal,
+              ),
+            ),
+          ],
+        ),
+        minTileHeight: 48.h,
+        backgroundColor: Colors.white,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.r)),
+        children: <Widget>[ListTile(title: Text('This is tile number 1'))],
+      ),
+    );
+  }
+}

--- a/lib/screens/home/my-mission-add/widget/selection_tile.dart
+++ b/lib/screens/home/my-mission-add/widget/selection_tile.dart
@@ -37,7 +37,7 @@ class SelectionTile extends StatelessWidget {
               title,
               style: AppTextStyles.bodyRegular(context, color: Colors.black),
             ),
-            Gap(30.w),
+            Gap(16.w),
             if (selected != null && include)
               Text(
                 selected!,

--- a/lib/screens/home/widgets/my_mission_list.dart
+++ b/lib/screens/home/widgets/my_mission_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/screens/home/widgets/mission_tile.dart';
 import 'package:live_frontend/screens/home/widgets/my_mission/mission_repeat.dart';
@@ -72,7 +73,9 @@ class _MyMissionListState extends State<MyMissionList> {
                 height: 48.w,
                 child: IconButton(
                   iconSize: 24.w,
-                  onPressed: () {},
+                  onPressed: () {
+                    context.pushNamed('my_mission_add');
+                  },
                   icon: const Icon(Icons.add),
                 ),
               ),

--- a/lib/screens/home/widgets/my_mission_list.dart
+++ b/lib/screens/home/widgets/my_mission_list.dart
@@ -97,9 +97,7 @@ class _MyMissionListState extends State<MyMissionList> {
                             MissionTime(scheduledTime: mission.scheduledTime),
                             Gap(12.w),
                             MissionRepeat(
-                              repeatInterval: mission.repeatDays
-                                  .map((e) => e.label)
-                                  .join(', '),
+                              repeatInterval: mission.repeatDay.label,
                             ),
                           ],
                         ),

--- a/lib/screens/mypage/mypage_screen.dart
+++ b/lib/screens/mypage/mypage_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
-import 'package:live_frontend/widgets/saeip_button.dart';
 import 'package:live_frontend/widgets/saeip_navigation_bar.dart';
-import 'package:go_router/go_router.dart';
 
 class MyPageScreen extends StatelessWidget {
   const MyPageScreen({super.key});
@@ -11,12 +9,7 @@ class MyPageScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: SaeipAppBar(title: 'My Page'),
-      body: Center(
-        child: SaeipButton(
-          text: '마이미션 추가',
-          onPressed: () => context.pushNamed('my_mission_add'),
-        ),
-      ),
+      body: Center(child: Text('My Page Content')),
       bottomNavigationBar: const SaeipNavigationBar(initialIndex: 4),
     );
   }

--- a/lib/screens/mypage/mypage_screen.dart
+++ b/lib/screens/mypage/mypage_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
+import 'package:live_frontend/widgets/saeip_button.dart';
 import 'package:live_frontend/widgets/saeip_navigation_bar.dart';
+import 'package:go_router/go_router.dart';
 
 class MyPageScreen extends StatelessWidget {
   const MyPageScreen({super.key});
@@ -9,7 +11,12 @@ class MyPageScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: SaeipAppBar(title: 'My Page'),
-      body: const Center(child: Text('마이페이지')),
+      body: Center(
+        child: SaeipButton(
+          text: '마이미션 추가',
+          onPressed: () => context.pushNamed('my_mission_add'),
+        ),
+      ),
       bottomNavigationBar: const SaeipNavigationBar(initialIndex: 4),
     );
   }

--- a/lib/widgets/saeip_search_bar.dart
+++ b/lib/widgets/saeip_search_bar.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import './utils/debouncer.dart';
 import './utils/recent_search_repo.dart';
-import 'package:live_frontend/screens/forum/forum_search_detail_screen.dart';
+// import 'package:live_frontend/screens/forum/forum_search_detail_screen.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -104,14 +104,14 @@ class _SaeipSearchBarState extends State<SaeipSearchBar> {
 
   void _openDetail() {
     // 검색 상세 화면으로 이동
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => ForumSearchDetailScreen(
-          externalController: widget.controller,
-          hintText: widget.hintText,
-        ),
-      ),
-    );
+    // Navigator.of(context).push(
+    // MaterialPageRoute(
+    //   builder: (_) => ForumSearchDetailScreen(
+    //     externalController: widget.controller,
+    //     hintText: widget.hintText,
+    //   ),
+    //   ),
+    // );
   }
 
   void _handleSearchPressed() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1373,6 +1373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: ba2cd5af24ff20a0b8d609cec3f40e5b0744d2a71804a2616ae086b9c19d19a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1514,6 +1522,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: "0c0c6219878b363a2d5f40c7afb159d845f253d061dc3c822aa0d5fe0f721982"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1546,6 +1546,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  time_picker_spinner:
+    dependency: "direct main"
+    description:
+      name: time_picker_spinner
+      sha256: d1d37855c13d6c433bee0ed37c7c32f948737f41ee8bd4e4d858312fc4ff3f70
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   carousel_slider: ^5.1.1
+  table_calendar: ^3.2.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
     sdk: flutter
   carousel_slider: ^5.1.1
   table_calendar: ^3.2.0
+  time_picker_spinner: ^1.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [ ]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 미션 추가 화면을 구현하였습니다.
> <img width="306" height="900" alt="스크린샷 2025-08-22 오후 11 58 56" src="https://github.com/user-attachments/assets/53805375-e012-4334-b1c0-81a6a45fe170" />


&nbsp;
### 🔍 작업 상세 내용

- [x] 미션 추가 화면 구현
  - 시작일을 선택하면 시작일 이전 날짜로 종료일 선택 불가
  - 종료일을 선택하면 종료일 이후 날짜로 시작일 선택 불가
  - 폼 용 모델과 실제 추가 api 돌릴 모델 추가

&nbsp;
### 💬 리뷰어에게 전달할 내용 (선택)

> 이후 시연 영상을 위해 미션 리스트를 전역 상태로 임시 처리를 해야할 것 같습니다. 

&nbsp;
### 🔗 관련 이슈 (선택)

- Resolves: #36
- Ref: #참고이슈
- Related to: #연관이슈