### PR TITLE
Feat: 주간리포트탭 일간 미션 완료 리스트 api 연동

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SaltySalt77 @hyunho4532
+* @SaltySalt77

--- a/lib/core/controllers/statistics_controller.dart
+++ b/lib/core/controllers/statistics_controller.dart
@@ -44,4 +44,15 @@ class StatisticsController {
       return null;
     }
   }
+
+  Future<DailyCompletedMissionsModel?> fetchDailyCompletedMissions(
+    String date,
+    MissionType missionType,
+  ) async {
+    try {
+      return await _repository.fetchDailyCompletedMissions(date, missionType);
+    } catch (e) {
+      return null;
+    }
+  }
 }

--- a/lib/core/repositories/statistics_repository.dart
+++ b/lib/core/repositories/statistics_repository.dart
@@ -84,4 +84,31 @@ class StatisticsRepository {
       return null;
     }
   }
+
+  Future<DailyCompletedMissionsModel?> fetchDailyCompletedMissions(
+    String date,
+    MissionType missionType,
+  ) async {
+    try {
+      final endpoint = missionType == MissionType.clover
+          ? '/api/v1/analysis/clover/daily'
+          : '/api/v1/analysis/my/daily';
+      final response = await _dio.get(
+        endpoint,
+        queryParameters: {'date': date},
+      );
+      final apiResponse =
+          ApiResponseModel<DailyCompletedMissionsModel>.fromJson(
+            response.data,
+            (json) => DailyCompletedMissionsModel.fromJson(
+              json as Map<String, dynamic>,
+            ),
+          );
+
+      return apiResponse.data;
+    } catch (e) {
+      debugPrint('Failed to fetch daily completed missions: $e');
+      return null;
+    }
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,6 @@ void main() async {
   };
 
   KakaoSdk.init(nativeAppKey: Env.kakaoNativeAppKey);
-  await Jiffy.setLocale('ko');
+  await Jiffy.setLocale('ko_Kr', startOfWeek: StartOfWeek.monday);
   runApp(const ProviderScope(child: MyApp()));
 }

--- a/lib/models/statistics_model.dart
+++ b/lib/models/statistics_model.dart
@@ -122,3 +122,38 @@ class GrowthSummary {
       _$GrowthSummaryFromJson(json);
   Map<String, dynamic> toJson() => _$GrowthSummaryToJson(this);
 }
+
+@JsonSerializable()
+class DailyCompletedMissionsModel {
+  final String date;
+  @DayOfWeekConverter()
+  final DayOfWeek dayOfWeek;
+  final List<CompletedMission> completedMissions;
+  DailyCompletedMissionsModel({
+    required this.date,
+    required this.dayOfWeek,
+    required this.completedMissions,
+  });
+
+  factory DailyCompletedMissionsModel.fromJson(Map<String, dynamic> json) =>
+      _$DailyCompletedMissionsModelFromJson(json);
+  Map<String, dynamic> toJson() => _$DailyCompletedMissionsModelToJson(this);
+}
+
+@JsonSerializable()
+class CompletedMission {
+  final int missionId;
+  final int missionRecordId;
+  final String missionTitle;
+  final String completedAt;
+
+  CompletedMission({
+    required this.missionId,
+    required this.missionRecordId,
+    required this.missionTitle,
+    required this.completedAt,
+  });
+  factory CompletedMission.fromJson(Map<String, dynamic> json) =>
+      _$CompletedMissionFromJson(json);
+  Map<String, dynamic> toJson() => _$CompletedMissionToJson(this);
+}

--- a/lib/models/statistics_model.g.dart
+++ b/lib/models/statistics_model.g.dart
@@ -101,3 +101,37 @@ const _$CloverMissionCategoryEnumMap = {
   CloverMissionCategory.hobby: 'HOBBY',
   CloverMissionCategory.study: 'STUDY',
 };
+
+DailyCompletedMissionsModel _$DailyCompletedMissionsModelFromJson(
+  Map<String, dynamic> json,
+) => DailyCompletedMissionsModel(
+  date: json['date'] as String,
+  dayOfWeek: const DayOfWeekConverter().fromJson(json['dayOfWeek'] as String),
+  completedMissions: (json['completedMissions'] as List<dynamic>)
+      .map((e) => CompletedMission.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$DailyCompletedMissionsModelToJson(
+  DailyCompletedMissionsModel instance,
+) => <String, dynamic>{
+  'date': instance.date,
+  'dayOfWeek': const DayOfWeekConverter().toJson(instance.dayOfWeek),
+  'completedMissions': instance.completedMissions,
+};
+
+CompletedMission _$CompletedMissionFromJson(Map<String, dynamic> json) =>
+    CompletedMission(
+      missionId: (json['missionId'] as num).toInt(),
+      missionRecordId: (json['missionRecordId'] as num).toInt(),
+      missionTitle: json['missionTitle'] as String,
+      completedAt: json['completedAt'] as String,
+    );
+
+Map<String, dynamic> _$CompletedMissionToJson(CompletedMission instance) =>
+    <String, dynamic>{
+      'missionId': instance.missionId,
+      'missionRecordId': instance.missionRecordId,
+      'missionTitle': instance.missionTitle,
+      'completedAt': instance.completedAt,
+    };

--- a/lib/providers/statistics_provider.dart
+++ b/lib/providers/statistics_provider.dart
@@ -50,3 +50,15 @@ final monthlyGrowthProvider =
       final controller = ref.read(statisticsControllerProvider);
       return controller.fetchMonthlyGrowth(yearMonth);
     });
+
+final dailyCompletedMissionsProvider =
+    FutureProvider.family<DailyCompletedMissionsModel?, StatisticsApiPayload>((
+      ref,
+      payload,
+    ) {
+      final controller = ref.read(statisticsControllerProvider);
+      return controller.fetchDailyCompletedMissions(
+        payload.yearMonth,
+        payload.missionType,
+      );
+    });

--- a/lib/routers/app_router.dart
+++ b/lib/routers/app_router.dart
@@ -197,6 +197,7 @@ final routerProvider = Provider<GoRouter>((ref) {
               return WeeklyReportScreen(
                 referenceDate: referenceDate,
                 missionType: missionType,
+                selectedIndex: int.tryParse(qp['selectedIndex'] ?? '') ?? 0,
               );
             },
           ),

--- a/lib/screens/statistics/statistics_screen.dart
+++ b/lib/screens/statistics/statistics_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/screens/statistics/widgets/mission_completion_gauge.dart';
@@ -87,6 +88,27 @@ class _StatisticsScreenState extends ConsumerState<StatisticsScreen>
   Widget _buildStatisticsContent({
     required int tabIndex, // 0: 클로버 미션, 1: 마이 미션
   }) {
+    void onBarTapped(int index) {
+      debugPrint('Bar $index tapped');
+      final refDate = Jiffy.parse(
+        _currentAnchor,
+      ).startOf(Unit.week).add(days: index);
+
+      debugPrint(
+        'Navigating to date: ${refDate.format(pattern: 'yyyy-MM-dd')}',
+      );
+      context.pushNamed(
+        'weekly_report',
+        queryParameters: {
+          'referenceDate': refDate.format(pattern: 'yyyy-MM-dd'),
+          'missionType': tabIndex == 0
+              ? MissionType.clover.name
+              : MissionType.my.name,
+          'selectedIndex': index.toString(),
+        },
+      );
+    }
+
     return ListView(
       children: [
         Container(
@@ -108,6 +130,7 @@ class _StatisticsScreenState extends ConsumerState<StatisticsScreen>
                     ? MissionType.clover
                     : MissionType.my,
                 currentAnchor: _currentAnchor,
+                onBarTapped: onBarTapped,
               ),
               WeekNavigator(
                 currentAnchor: Jiffy.parse(_currentAnchor),

--- a/lib/screens/statistics/weekly-report/weekly_report_screen.dart
+++ b/lib/screens/statistics/weekly-report/weekly_report_screen.dart
@@ -4,6 +4,7 @@ import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/screens/statistics/weekly-report/widget/mission_list.dart';
 import 'package:live_frontend/screens/statistics/widgets/week_navigator.dart';
 import 'package:live_frontend/screens/statistics/widgets/weekly_bar_chart.dart';
+import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/widgets/saeip_app_bar.dart';
 
 class WeeklyReportScreen extends StatefulWidget {
@@ -49,23 +50,30 @@ class _WeeklyReportScreenState extends State<WeeklyReportScreen> {
       ),
       body: SafeArea(
         child: Container(
-          padding: const EdgeInsets.all(16.0),
+          color: AppColors.blackBlack0,
           child: Column(
             children: [
-              WeeklyBarChart(
-                missionType: widget.missionType,
-                currentAnchor: _anchor.format(pattern: 'yyyy-MM-dd'),
-                selectedIndex: _selectedIndex,
-                onBarTapped: onBarTapped,
-              ),
-              WeekNavigator(
-                currentAnchor: _anchor,
-                onChanged: (start) {
-                  setState(() {
-                    _anchor = start;
-                    _selectedIndex = 0;
-                  });
-                },
+              Container(
+                color: Colors.white,
+                child: Column(
+                  children: [
+                    WeeklyBarChart(
+                      missionType: widget.missionType,
+                      currentAnchor: _anchor.format(pattern: 'yyyy-MM-dd'),
+                      selectedIndex: _selectedIndex,
+                      onBarTapped: onBarTapped,
+                    ),
+                    WeekNavigator(
+                      currentAnchor: _anchor,
+                      onChanged: (start) {
+                        setState(() {
+                          _anchor = start;
+                          _selectedIndex = 0;
+                        });
+                      },
+                    ),
+                  ],
+                ),
               ),
               Expanded(
                 child: MissionList(

--- a/lib/screens/statistics/weekly-report/weekly_report_screen.dart
+++ b/lib/screens/statistics/weekly-report/weekly_report_screen.dart
@@ -9,11 +9,13 @@ import 'package:live_frontend/widgets/saeip_app_bar.dart';
 class WeeklyReportScreen extends StatefulWidget {
   final Jiffy referenceDate;
   final MissionType missionType;
+  final int selectedIndex;
 
   const WeeklyReportScreen({
     super.key,
     required this.referenceDate,
     required this.missionType,
+    required this.selectedIndex,
   });
 
   @override
@@ -21,14 +23,14 @@ class WeeklyReportScreen extends StatefulWidget {
 }
 
 class _WeeklyReportScreenState extends State<WeeklyReportScreen> {
-  late Jiffy _anchor; // Monday of the reference week
-  late int _selectedIndex; // 0..6 where 0 = Monday
+  late Jiffy _anchor;
+  late int _selectedIndex;
 
   @override
   void initState() {
     super.initState();
     _anchor = widget.referenceDate.startOf(Unit.week);
-    _selectedIndex = (widget.referenceDate.date - DateTime.monday) % 7;
+    _selectedIndex = widget.selectedIndex;
   }
 
   @override
@@ -60,7 +62,7 @@ class _WeeklyReportScreenState extends State<WeeklyReportScreen> {
               ),
               Expanded(
                 child: MissionList(
-                  referenceDate: _anchor,
+                  referenceDate: _anchor.add(days: _selectedIndex),
                   type: widget.missionType,
                 ),
               ),

--- a/lib/screens/statistics/weekly-report/weekly_report_screen.dart
+++ b/lib/screens/statistics/weekly-report/weekly_report_screen.dart
@@ -35,6 +35,12 @@ class _WeeklyReportScreenState extends State<WeeklyReportScreen> {
 
   @override
   Widget build(BuildContext context) {
+    void onBarTapped(int index) {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
+
     return Scaffold(
       appBar: SaeipAppBar(
         title: widget.missionType == MissionType.my
@@ -50,6 +56,7 @@ class _WeeklyReportScreenState extends State<WeeklyReportScreen> {
                 missionType: widget.missionType,
                 currentAnchor: _anchor.format(pattern: 'yyyy-MM-dd'),
                 selectedIndex: _selectedIndex,
+                onBarTapped: onBarTapped,
               ),
               WeekNavigator(
                 currentAnchor: _anchor,

--- a/lib/screens/statistics/weekly-report/widget/mission_list.dart
+++ b/lib/screens/statistics/weekly-report/widget/mission_list.dart
@@ -44,15 +44,6 @@ class MissionList extends ConsumerWidget {
                 textAlign: TextAlign.left,
               ),
 
-              // Gap(16.h),
-              // MissionListItem(
-              //   type: type,
-              //   missionTitle: 'My Mission',
-              //   completedTime: '09:23',
-              //   onTap: () {
-              //     // Handle tap
-              //   },
-              // ),
               if (data == null || data.completedMissions.isEmpty) ...[
                 Gap(16.h),
                 Text(

--- a/lib/screens/statistics/weekly-report/widget/mission_list.dart
+++ b/lib/screens/statistics/weekly-report/widget/mission_list.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:live_frontend/models/my_mission_model.dart';
+import 'package:live_frontend/providers/statistics_provider.dart';
 import 'package:live_frontend/screens/statistics/weekly-report/widget/mission_list_item.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
 
-class MissionList extends StatelessWidget {
+class MissionList extends ConsumerWidget {
   final Jiffy referenceDate;
   final MissionType type;
   const MissionList({
@@ -17,29 +19,70 @@ class MissionList extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.symmetric(vertical: 32.h, horizontal: 16.w),
-      color: AppColors.blackBlack0,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            referenceDate.format(pattern: 'yyyy년 MM월 dd일'),
-            style: AppTextStyles.subtitleMedium(context),
-            textAlign: TextAlign.left,
-          ),
-          Gap(16.h),
-          MissionListItem(
-            type: type,
-            missionTitle: 'My Mission',
-            completedTime: '09:23',
-            onTap: () {
-              // Handle tap
-            },
-          ),
-        ],
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dailyCompletedMissionsAsync = ref.watch(
+      dailyCompletedMissionsProvider(
+        StatisticsApiPayload(
+          yearMonth: referenceDate.format(pattern: 'yyyy-MM-dd'),
+          missionType: type,
+        ),
       ),
+    );
+
+    return dailyCompletedMissionsAsync.when(
+      data: (data) {
+        return Container(
+          padding: EdgeInsets.symmetric(vertical: 32.h, horizontal: 16.w),
+          width: double.infinity,
+          color: AppColors.blackBlack0,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                referenceDate.format(pattern: 'yyyy년 MM월 dd일'),
+                style: AppTextStyles.subtitleMedium(context),
+                textAlign: TextAlign.left,
+              ),
+
+              // Gap(16.h),
+              // MissionListItem(
+              //   type: type,
+              //   missionTitle: 'My Mission',
+              //   completedTime: '09:23',
+              //   onTap: () {
+              //     // Handle tap
+              //   },
+              // ),
+              if (data == null || data.completedMissions.isEmpty) ...[
+                Gap(16.h),
+                Text(
+                  '완료한 미션이 없습니다.',
+                  style: AppTextStyles.bodyMedium(
+                    context,
+                  ).copyWith(color: AppColors.blackBlack5),
+                ),
+              ] else
+                ...data.completedMissions.map(
+                  (mission) => Padding(
+                    padding: EdgeInsets.only(top: 16.h),
+                    child: MissionListItem(
+                      type: type,
+                      missionTitle: mission.missionTitle,
+                      completedTime: Jiffy.parse(
+                        mission.completedAt,
+                      ).format(pattern: 'HH:mm'),
+                      onTap: () {
+                        // Handle tap
+                      },
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(child: Text('Error: $error')),
     );
   }
 }

--- a/lib/screens/statistics/weekly-report/widget/mission_list_item.dart
+++ b/lib/screens/statistics/weekly-report/widget/mission_list_item.dart
@@ -22,7 +22,7 @@ class MissionListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: Colors.transparent,
+      color: Colors.white,
       child: InkWell(
         onTap: onTap,
         child: Container(

--- a/lib/screens/statistics/widgets/weekly_bar_chart.dart
+++ b/lib/screens/statistics/widgets/weekly_bar_chart.dart
@@ -2,46 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:jiffy/jiffy.dart';
 import 'package:live_frontend/models/my_mission_model.dart';
 import 'package:live_frontend/providers/statistics_provider.dart';
 import 'package:live_frontend/theme/app_colors.dart';
 import 'package:live_frontend/theme/app_text_styles.dart';
-import 'package:go_router/go_router.dart';
 
 class WeeklyBarChart extends ConsumerWidget {
   final int? selectedIndex;
   final MissionType missionType;
   final String currentAnchor;
+  final Function(int index) onBarTapped;
 
   const WeeklyBarChart({
     super.key,
     this.selectedIndex,
     required this.missionType,
     required this.currentAnchor,
+    required this.onBarTapped,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    void onBarTapped(int index) {
-      debugPrint('Bar $index tapped');
-      final refDate = Jiffy.parse(
-        currentAnchor,
-      ).startOf(Unit.week).add(days: index);
-
-      debugPrint(
-        'Navigating to date: ${refDate.format(pattern: 'yyyy-MM-dd')}',
-      );
-      context.pushNamed(
-        'weekly_report',
-        queryParameters: {
-          'referenceDate': refDate.format(pattern: 'yyyy-MM-dd'),
-          'missionType': missionType.name,
-          'selectedIndex': index.toString(),
-        },
-      );
-    }
-
     final weeklyMissionSummaryAsync = ref.watch(
       weeklyCompletionRatesProvider(
         StatisticsApiPayload(

--- a/lib/screens/statistics/widgets/weekly_bar_chart.dart
+++ b/lib/screens/statistics/widgets/weekly_bar_chart.dart
@@ -24,6 +24,7 @@ class WeeklyBarChart extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     void onBarTapped(int index) {
+      debugPrint('Bar $index tapped');
       final refDate = Jiffy.parse(
         currentAnchor,
       ).startOf(Unit.week).add(days: index);
@@ -140,7 +141,7 @@ class WeeklyBarChart extends ConsumerWidget {
                 touchCallback: (event, response) {
                   if (event is FlTapUpEvent && response?.spot != null) {
                     final index = response!.spot!.touchedBarGroupIndex;
-                    onBarTapped.call(index);
+                    onBarTapped(index);
                   }
                 },
               ),

--- a/lib/screens/statistics/widgets/weekly_bar_chart.dart
+++ b/lib/screens/statistics/widgets/weekly_bar_chart.dart
@@ -28,11 +28,16 @@ class WeeklyBarChart extends ConsumerWidget {
       final refDate = Jiffy.parse(
         currentAnchor,
       ).startOf(Unit.week).add(days: index);
+
+      debugPrint(
+        'Navigating to date: ${refDate.format(pattern: 'yyyy-MM-dd')}',
+      );
       context.pushNamed(
         'weekly_report',
         queryParameters: {
           'referenceDate': refDate.format(pattern: 'yyyy-MM-dd'),
           'missionType': missionType.name,
+          'selectedIndex': index.toString(),
         },
       );
     }

--- a/lib/screens/statistics/widgets/weekly_bar_chart.dart
+++ b/lib/screens/statistics/widgets/weekly_bar_chart.dart
@@ -90,11 +90,22 @@ class WeeklyBarChart extends ConsumerWidget {
                       if (value.toInt() < days.length) {
                         return Padding(
                           padding: EdgeInsets.only(top: 8.h),
-                          child: Text(
-                            days[value.toInt()],
-                            style: AppTextStyles.smallMedium(
-                              context,
-                              color: Colors.black,
+                          child: TextButton(
+                            onPressed: () {
+                              onBarTapped(value.toInt());
+                            },
+                            style: TextButton.styleFrom(
+                              padding: EdgeInsets.zero,
+                              minimumSize: Size(24.w, 24.h),
+                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                              alignment: Alignment.center,
+                            ),
+                            child: Text(
+                              days[value.toInt()],
+                              style: AppTextStyles.smallMedium(
+                                context,
+                                color: Colors.black,
+                              ),
                             ),
                           ),
                         );


### PR DESCRIPTION
### ✅ PR 타입 (하나 이상 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [x]  리팩토링 / 코드 개선
- [ ]  의존성 / 환경 설정 변경
- [x]  버그 수정
- [ ]  기타 (하단에 설명)

&nbsp;
### ✨ 어떤 내용인가요?

> 일일 미션 완료 리스트 api를 연동하였습니다. jiffy의 로케일 설정 중 start of week이 일요일로 되어있어 발생한 문제를 해결하였습니다. 

&nbsp;
### 🔍 작업 상세 내용

- [x] 일일 미션 완료 리스트 api 연동
- [x] 잘못된 날짜의 데이터를 가져오는 현상
- [x] 배경 색상이 이상하게 적용된 현상
- [x] 막대그래프에서 요일을 탭해도 이동하도록 처리

### 🔗 관련 이슈 (선택)

- Resolves: #56
- Ref: #참고이슈
- Related to: #연관이슈